### PR TITLE
#170442086 - Add single account view.

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from account.views import AccountView
+from account.views import AccountView, AccountDetail
 
 
 app_name = "account"
 urlpatterns = [
     path('', AccountView.as_view(), name="base"),
+    path('<int:pk>/', AccountDetail.as_view(), name="detail"),
 ]

--- a/account/views.py
+++ b/account/views.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from account.models import Account
 from account.serializers import AccountSerializer
 
 
@@ -30,4 +31,21 @@ class AccountView(APIView):
         """
         accounts = request.user.account_set.all()
         serializer = AccountSerializer(accounts, many=True)
+        return Response(serializer.data)
+
+
+class AccountDetail(APIView):
+    """
+    Accounts against a particular account.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, pk):
+        """
+        return a single account given its pk
+        """
+        account = Account.objects.get(id=pk)
+        if account.user != request.user:
+            return Response('Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
+        serializer = AccountSerializer(account)
         return Response(serializer.data)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,8 @@
-from rest_framework.test import APITestCase
 from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from account.models import Account
+from bank.models import Bank
 
 
 class BaseTestCase(APITestCase):
@@ -27,3 +30,11 @@ class BaseTestCase(APITestCase):
         url = reverse('authentication:login')
         response = self.client.post(url, user, format='json')
         return response.data['access']
+
+    @staticmethod
+    def create_bank(bank_details):
+        """
+        creates an instance of Bank
+        using the given bank details which is a dictionary
+        """
+        return Bank.objects.create(**bank_details)

--- a/tests/sample_data/account.py
+++ b/tests/sample_data/account.py
@@ -1,13 +1,3 @@
-from bank.models import Bank
-
-
-def create_bank(bank_details):
-    """
-    creates an instance of Bank
-    using the given bank details which is a dictionary
-    """
-    return Bank.objects.create(**bank_details)
-
 def account_1(bank):
     """
     Creates sample account data.

--- a/tests/sample_data/authentication.py
+++ b/tests/sample_data/authentication.py
@@ -10,3 +10,15 @@ user_1_login = {
     "phone_number": "25670000000",
     "password": "thisIs6@5",
 }
+user_2 = {
+    "phone_number": "2567000001",
+    "password": "thisIs6@5",
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "dob": "1995-04-22",
+    "nin": "userNinNumbe2"
+}
+user_2_login = {
+    "phone_number": "2567000001",
+    "password": "thisIs6@5",
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -3,9 +3,8 @@ from rest_framework import status
 
 from account.models import Account
 from tests.base import BaseTestCase
-from tests.sample_data.account import (account_1, create_bank,
-                                       incomplete_account)
-from tests.sample_data.authentication import user_1, user_1_login
+from tests.sample_data.account import account_1, incomplete_account
+from tests.sample_data.authentication import user_1, user_1_login, user_2, user_2_login
 from tests.sample_data.bank import bank_1
 
 
@@ -16,16 +15,24 @@ class AccountTestCase(BaseTestCase):
 
     def setUp(self):
         self.signup_user(user_1)
+        self.signup_user(user_2)
         self.token = self.login_user(user_1_login)
+        self.token_2 = self.login_user(user_2_login)
         self.base_url = reverse('account:base')
-        self.bank = create_bank(bank_1)
+        self.bank = self.create_bank(bank_1)
+    
+    def create_account(self, account_details):
+        """
+        create an account by posting the create account endpoint
+        """
+        self.add_token(self.token)
+        return self.client.post(self.base_url, account_details, format='json')
 
     def test_create_account(self):
         """
         Ensure logged in user can create account
         """
-        self.add_token(self.token)
-        response = self.client.post(self.base_url, account_1(self.bank), format='json')
+        response = self.create_account(account_1(self.bank))
         accounts = Account.objects.all()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertGreater(len(accounts), 0)
@@ -34,8 +41,7 @@ class AccountTestCase(BaseTestCase):
         """
         Ensure a missing field results in a 400 error.
         """
-        self.add_token(self.token)
-        response = self.client.post(self.base_url, incomplete_account(self.bank), format='json')
+        response = self.create_account(incomplete_account(self.bank))
         accounts = Account.objects.all()
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(len(accounts), 0)
@@ -45,7 +51,28 @@ class AccountTestCase(BaseTestCase):
         Endpoint should return a list of accounts
         """
         self.add_token(self.token)
-        self.client.post(self.base_url, account_1(self.bank), format='json')
+        self.create_account(account_1(self.bank))
         response = self.client.get(self.base_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data), 0)
+
+    def test_get_single_account(self):
+        """
+        Endpoint should return a single object
+        """
+        account = self.create_account(account_1(self.bank))
+        url = reverse('account:detail', kwargs={'pk': account.data['id']})
+        self.add_token(self.token)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unauthorized_access_to_account(self):
+        """
+        User should not be able to check account
+        belonging to another user
+        """
+        account = self.create_account(account_1(self.bank))
+        url = reverse('account:detail', kwargs={'pk': account.data['id']})
+        self.add_token(self.token_2)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
#### What does this PR do?
- Adds ability to view a single account by providing its id.

#### Description of tasks completed.
- Add endpoint to return account given its id.
- Ensure user can only view his accounts.
- Add tests for functionality.
- Refactor tests.

#### How this can be tested.
- Checkout branch `ft-view-single-account-170442086`.
- Run application using command. `python manage.py runserver`.
- View all accounts you have created so far by sending a GET request to `/account/`.
- To view a particular account. Use its id in a GET request like this. `/account/<int:id>/`.

#### Relevant PT stories
[#170442086](https://www.pivotaltracker.com/story/show/170442086)