### PR TITLE
#170441402 - Edit error message upon sign up of duplicate accounts.

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -18,7 +18,7 @@ class UserView(APIView):
                 serializer.save()
             except IntegrityError:
                 return Response(
-                    "Number already exists",
+                    "Number or NIN already exists",
                     status=status.HTTP_400_BAD_REQUEST)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/sample_data/authentication.py
+++ b/tests/sample_data/authentication.py
@@ -6,6 +6,24 @@ user_1 = {
     "dob": "1995-04-22",
     "nin": "userNinNumber"
 }
+
+user_duplicate_nin = {
+    "phone_number": "25670000002",
+    "password": "thisIs6@5",
+    "first_name": "John",
+    "last_name": "Doe",
+    "dob": "1995-04-22",
+    "nin": "userNinNumber"
+}
+
+incomplete_user = {
+    "phone_number": "25670000002",
+    "password": "thisIs6@5",
+    "first_name": "John",
+    "dob": "1995-04-22",
+    "nin": "userNinNumber"
+}
+
 user_1_login = {
     "phone_number": "25670000000",
     "password": "thisIs6@5",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,8 @@ from rest_framework import status
 
 from authentication.models import User
 from tests.base import BaseTestCase
-from tests.sample_data.authentication import user_1, user_1_login
+from tests.sample_data.authentication import (incomplete_user, user_1,
+                                              user_1_login, user_duplicate_nin)
 
 
 class AuthTests(BaseTestCase):
@@ -20,6 +21,24 @@ class AuthTests(BaseTestCase):
         """
         self.signup_user(user_1)
         response = self.signup_user(user_1)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, 'Number or NIN already exists')
+
+    def test_duplicate_nin(self):
+        """
+        Ensure error message for already existing
+        NIN
+        """
+        self.signup_user(user_1)
+        response = self.signup_user(user_duplicate_nin)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, 'Number or NIN already exists')
+
+    def test_incomplete_user(self):
+        """
+        Ensure 400 error if a field is missing
+        """
+        response = self.signup_user(incomplete_user)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_login(self):


### PR DESCRIPTION
#### What does this PR do?
- The NIN field is unique and therefore a duplicate NIN should result in error that hints at the NIN. However the current error only mentions the duplicate number. This PR fixes that. 

#### Description of tasks completed.
-  Ensure error message includes NIN since NIN must be unique.
- Add tests for functionality.

#### How this can be tested.
- Sign up a user. 
- Sign up another user but change the number and leave the NIN constatnt.
- 400 error with message saying `Number or NIN already exists`.
- Sign up another user but keep the number the same is the first user and change the NIN.
- Again you should be greeted with a `400` error.

#### PT Stories.
[#170441402](https://www.pivotaltracker.com/story/show/170441402)