### PR TITLE
#170660570 - Handle Internal server errors in the accounts view.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 #### Demo links
 - Backend hosted on heroku. - `https://momobank.herokuapp.com/`
+- Link to Swagger docs. -  `https://momobank.herokuapp.com/swagger/`
 
 #### Requirements to run application.
 - Python >= 3.5
@@ -35,7 +36,7 @@
 |`GET` /transactions/| Return all transactions.| Returns all transactions in the db.|
 |`GET` /transactions/[transaction_id]/| View a single transaction. | Detail view of a single transaction. |
 |`PUT` /transactions/[transaction_id]/| Update a single transaction. | Update a transaction status to successful. |
-Link to Swagger docs. `https://momobank.herokuapp.com/swagger/`
+
 
 ## Built With
 

--- a/account/views.py
+++ b/account/views.py
@@ -1,5 +1,5 @@
 from django.db import IntegrityError
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -45,7 +45,7 @@ class AccountDetail(APIView):
         """
         return a single account given its pk
         """
-        account = Account.objects.get(id=pk)
+        account = get_object_or_404(Account, id=pk)
         if account.user != request.user:
             return Response(
                 'Unauthorized', status=status.HTTP_401_UNAUTHORIZED)
@@ -63,7 +63,7 @@ class AccountTransactions(APIView):
         """
         return all transactions on a given account
         """
-        account = Account.objects.get(id=pk)
+        account = get_object_or_404(Account, id=pk)
         transactions = account.transaction_set.all()
         if account.user != request.user:
             return Response(

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -61,6 +61,16 @@ class AccountTestCase(BaseTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_non_existing_account(self):
+        """
+        Endpoint should return a 404 error
+        for accounts that do not exist
+        """
+        url = reverse('account:detail', kwargs={'pk': 100})
+        self.add_token(self.token)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_unauthorized_access_to_account(self):
         """
         User should not be able to check account

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -106,6 +106,15 @@ class TransactionsTestCase(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data), 0)
 
+    def test_account_404_transactions(self):
+        """
+        Ensure account not existing returns a 404 not a 500
+        """
+        url = reverse(
+            'account:transactions', kwargs={'pk': 100})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    
     def test_get_single_transaction(self):
         """
         Endpoint should return a single transaction


### PR DESCRIPTION
#### What does this PR do?
- Handles internal server errors that were resulting from trying to query an account that does not exist.

#### Description of tasks completed.
- Write tests to ensure the endpoints return 404 errors as opposed to the current 500 errors they are returning.
- Replace query for account with Django shortcut that handles 404 error if item is not found in the database.

#### How this can be tested.
- Currently trying to get an account that does not exist returns a 500 error.
- Trying to get transactions on an account that does not exist returns a 500 error.
- You try this out on the `dev` branch before checking out the bug-fix branch.
- Try the same queries on the bug-fix branch.

#### Relevant PT stories
[#170660570](https://www.pivotaltracker.com/story/show/170660570)
[#170449846](https://www.pivotaltracker.com/story/show/170449846)